### PR TITLE
None fix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+3.2.1
+ * fixes bug related to unspecified station_url or event_url
+
 3.2.0
  * fixes compile issue with XCode 16
  * updates installation to R=4.2 and other package version updates

--- a/ispaq/concierge.py
+++ b/ispaq/concierge.py
@@ -133,10 +133,12 @@ class Concierge(object):
         # add alias of EARTHSCOPE for IRIS
         if user_request.dataselect_url.upper() == "EARTHSCOPE":
             user_request.dataselect_url = "IRIS"
-        if user_request.station_url.upper() == "EARTHSCOPE":
-            user_request.station_url = "IRIS"
-        if (user_request.event_url == "IRIS" or user_request.event_url.upper() == "EARTHSCOPE"):
-            user_request.event_url = "USGS"
+        if user_request.station_url is not None:
+            if user_request.station_url.upper() == "EARTHSCOPE":
+                user_request.station_url = "IRIS"
+        if user_request.event_url is not None:
+            if (user_request.event_url == "IRIS" or user_request.event_url.upper() == "EARTHSCOPE"):
+                user_request.event_url = "USGS"
             
         # Add dataselect clients and URLs or reference a local file
         self.dataselect_type = None

--- a/ispaq/irisseismic.py
+++ b/ispaq/irisseismic.py
@@ -448,7 +448,7 @@ def _userAgent():
     Create user agent string for use with new("IrisClient")
     """
     # ispaq_version = ispaq.__version__
-    ispaq_version = "3.2.0"
+    ispaq_version = "3.2.1"
 
     r_agent_string = ro.r(
         "paste0('IRISSeismic/',installed.packages()['IRISSeismic','Version'],' RCurl/',installed.packages()['RCurl','Version'],' R/',R.version$major,'.',R.version$minor,' ',version$platform,' ISPAQ/')"

--- a/ispaq/ispaq.py
+++ b/ispaq/ispaq.py
@@ -15,7 +15,7 @@ import subprocess
 from _ast import Try
 from numpy.random import sample
 
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 
 # dictionary of currently defined ISPAQ metric groups and business logic
 # for comparison with R package IRISMustangMetrics/ISPAQUtils.R json


### PR DESCRIPTION
Bug fix for concierge when station_url or event_url is unspecified in the preference file.

```
 if user_request.dataselect_url.upper() == "EARTHSCOPE":
        user_request.dataselect_url = "IRIS"
 if user_request.station_url is not None:
        if user_request.station_url.upper() == "EARTHSCOPE":
            user_request.station_url = "IRIS"
if user_request.event_url is not None:
        if (user_request.event_url == "IRIS" or user_request.event_url.upper() == "EARTHSCOPE"):
            user_request.event_url = "USGS"
```